### PR TITLE
Replace invalid characters when they cant be represented in the target charset

### DIFF
--- a/pyfis/aegmis/mis1_text.py
+++ b/pyfis/aegmis/mis1_text.py
@@ -54,13 +54,13 @@ class MIS1TextDisplay(MIS1Protocol):
 
     def simple_text(self, page, row, col, text, align = ALIGN_LEFT):
         text = self.merge_attributes(text)
-        text = text.encode("CP437")
+        text = text.encode("CP437", 'replace')
         data = [align, page, row, col] + list(text)
         return self.send_command(0x11, 0x00, data, expect_response=False)
 
     def text(self, page, row, col_start, col_end, text, align = ALIGN_LEFT):
         text = self.merge_attributes(text)
-        text = text.encode("CP437")
+        text = text.encode("CP437", 'replace')
         data = [align, page, row, col_start >> 8, col_start & 0xFF, col_end >> 8, col_end & 0xFF] + list(text)
         return self.send_command(0x15, 0x00, data, expect_response=False)
     

--- a/pyfis/aegmis/mis2_text.py
+++ b/pyfis/aegmis/mis2_text.py
@@ -45,7 +45,7 @@ class MIS2TextDisplay(MIS2Protocol):
         # Page 0xFF is the fallback page and will be saved permanently
         # Page 0xFE copies the page to all 10 slots
         text = self.merge_attributes(text)
-        text = text.encode("CP437")
+        text = text.encode("CP437", 'replace')
         data = [page, row, col_start >> 8, col_start & 0xFF, col_end >> 8, col_end & 0xFF, attrs] + list(text)
         return self.send_command(0x15, 0x00, data)
 

--- a/pyfis/aesys/dsa.py
+++ b/pyfis/aesys/dsa.py
@@ -34,14 +34,14 @@ class AesysDSA:
     
     def _checksum(self, data):
         checksum = sum(data)
-        data += "{:04X}".format(checksum & 0xFFFF).encode('ascii')
+        data += "{:04X}".format(checksum & 0xFFFF).encode('ascii', 'replace')
         return data
     
     def send_text(self, text):
         data = "\x01\x17P000060{text}".format(text=text)
         length = len(data)
         frame = "\x02AVIS{length:04X}{data}\x03".format(length=length, data=data)
-        frame = frame.encode('cp850')
+        frame = frame.encode('cp850', 'replace')
         frame = self._checksum(frame)
         if self.debug:
             print(frame)

--- a/pyfis/krone/k9000_fbm.py
+++ b/pyfis/krone/k9000_fbm.py
@@ -159,7 +159,7 @@ class Krone9000FBM:
             text = text[:length].ljust(length)
         for i, char in enumerate(text):
             address = start_address - i if descending else start_address + i
-            self.set_code(address, ord(char.encode('iso-8859-1')))
+            self.set_code(address, ord(char.encode('iso-8859-1', 'replace')))
     
     def get_status(self, addr):
         return self._get_fbm_status(self.read_status(addr)[0])

--- a/pyfis/microsyst/migra.py
+++ b/pyfis/microsyst/migra.py
@@ -196,7 +196,7 @@ class MigraTCP:
         if not escape and self.command_queue_enabled:
             # Separate non-escaped commands (texts) by 0x1F when queueing
             payload.append(0x1F)
-        payload.extend(command.encode('ascii'))
+        payload.extend(command.encode('ascii', 'replace'))
         if self.command_queue_enabled:
             self.command_queue.append(payload)
         else:

--- a/pyfis/splitflap_display/fields.py
+++ b/pyfis/splitflap_display/fields.py
@@ -238,7 +238,7 @@ class TextField(BaseField):
         if self.display_mapping is not None:
             code = self.inverse_display_mapping.get(char, self.home_pos)
         else:
-            code = ord(char.encode('iso-8859-1'))
+            code = ord(char.encode('iso-8859-1', 'replace'))
         x = self.x + pos * self.module_width
         return addr, code, x, self.y
 

--- a/pyfis/xatlabs/cheetah.py
+++ b/pyfis/xatlabs/cheetah.py
@@ -109,7 +109,7 @@ class xatLabsCheetah:
                 self.pixel_buffer[i] = 0
     
     def update_text_buffer(self, text):
-        characters = text.encode('iso-8859-1')
+        characters = text.encode('iso-8859-1', 'replace')
         for i in range(len(self.text_buffer)):
             if i < len(characters):
                 self.text_buffer[i] = characters[i]

--- a/pyfis/xatlabs/rgb_dsa.py
+++ b/pyfis/xatlabs/rgb_dsa.py
@@ -160,7 +160,7 @@ class xatLabsRGBDSAController:
         payload = []
 
         if type(text) in (list, tuple):
-            _text = "".join(d['text'] for d in text).encode("CP437")
+            _text = "".join(d['text'] for d in text).encode("CP437", 'replace')
             _segments = []
             pos = 0
             for i, t in enumerate(text):


### PR DESCRIPTION
When accepting input from arbitrary sources, it is preferable to ignore or replace characters that the target device cannot show, instead of aborting the program with an exception.